### PR TITLE
Develop/fix build dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ To build the image:
 To run the image and build the Linux components:
   docker run -u bob -v `pwd`/docker_artefacts:/linux/build/tmp/deploy/images <tagname> ./buildOnDocker.sh -r **repo** -b -**branch** -m **machine** **bitbake_args**
 
-  Where machine is one of sc594-som-ezit sc589-sam sc589-ezkit sc584-ezkit sc573-ezkit and bitbake_args are the bitbake commands to execute
+  Where **machine** is one of sc594-som-ezit sc589-mini sc589-ezkit sc584-ezkit sc573-ezkit and bitbake_args are the bitbake commands to execute. **repo** is the https address of the manifest containing username and password (or personal access token) in the form https://username:personalaccesstoken@github.com/username/reponame.git.

--- a/buildOnDocker.sh
+++ b/buildOnDocker.sh
@@ -109,7 +109,7 @@ git config --global user.name "${GIT_NAME}"
 git config --global color.ui false
 git config --global credential.helper store
 
-# change ownership of build directory to bob or we can't write to it
+# change ownership of build directory to bob or he can't write to it
 ${SCMD} chown -R `whoami` ${BUILD_DIR}
 
 # Sync repos

--- a/buildOnDocker.sh
+++ b/buildOnDocker.sh
@@ -13,7 +13,7 @@ GIT_EMAIL="win.tee@gmail.com"
 GIT_NAME="ADI Linux Test"
 SCRIPT_TARGET=""
 BUILD_ARGS=""
-BUILD_DIR="/linux/build"
+BUILD_DIR="build"
 
 function usage() {
     echo "$0: -r <repo> -b <branch> -m <machine> <bitbake commands>"
@@ -104,10 +104,12 @@ fi
 # Set up git credentials
 git config --global user.email "${GIT_EMAIL}"
 git config --global user.name "${GIT_NAME}"
-# Disable colour output or the repo init hangs waiting on input
+# Disable colour output or the repo init hangs waiting on input and cache username and password
 git config --global color.ui false
-
 git config --global credential.helper store
+
+# change ownership of build directory to bob or we can't write to it
+${SCMD} chown -R `whoami` ${BUILD_DIR}
 
 # Sync repos
 if [ ! -d ${WD}/.repo ]
@@ -117,4 +119,4 @@ fi
 ${WD}/bin/repo sync
 
 # Set up environment to build
-source ./setup-environment -m adsp-${SCRIPT_TARGET} -b  && bitbake -q ${BUILD_ARGS}
+source ./setup-environment -m adsp-${SCRIPT_TARGET} -b ${BUILD_DIR} && bitbake -q ${BUILD_ARGS}

--- a/buildOnDocker.sh
+++ b/buildOnDocker.sh
@@ -13,6 +13,7 @@ GIT_EMAIL="win.tee@gmail.com"
 GIT_NAME="ADI Linux Test"
 SCRIPT_TARGET=""
 BUILD_ARGS=""
+WORK_DIR="/linux"
 BUILD_DIR="build"
 
 function usage() {
@@ -78,7 +79,7 @@ sleep 5
 #  Locale used to stop python moaning
 export SET_LANG=en_US.UTF-8
 
-cd ${BUILD_DIR}
+cd ${WORK_DIR}
 WD=`pwd`
 
 # Do we need to use sudo, you really shouldn't be running as root. See the readme

--- a/buildOnDocker.sh
+++ b/buildOnDocker.sh
@@ -13,7 +13,7 @@ GIT_EMAIL="win.tee@gmail.com"
 GIT_NAME="ADI Linux Test"
 SCRIPT_TARGET=""
 BUILD_ARGS=""
-BUILD_DIR="/linux"
+BUILD_DIR="/linux/build"
 
 function usage() {
     echo "$0: -r <repo> -b <branch> -m <machine> <bitbake commands>"

--- a/buildOnDocker.sh
+++ b/buildOnDocker.sh
@@ -107,6 +107,8 @@ git config --global user.name "${GIT_NAME}"
 # Disable colour output or the repo init hangs waiting on input
 git config --global color.ui false
 
+git config --global credential.helper store
+
 # Sync repos
 if [ ! -d ${WD}/.repo ]
 then


### PR DESCRIPTION
Changes to buildOnDocker.sh:
 - added line to cache git credentials
 - distinguish between build directory and work directory so that images are output in /linux/build/tmp/deploy/images
 - set bob as owner of /linux/build so that he can write to it
 
Updated readme.md to explain how to pass credentials in.